### PR TITLE
updated version of spring-boot-maven-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,7 @@
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
+				<version>1.4.0.M2</version>
 			</plugin>
 
 		</plugins>


### PR DESCRIPTION
Hi Oliver,

changing plugin version of spring-boot-maven-plugin to 1.4.0.M2 (from 1.4.0-BUILD-SNAPSHOT) makes the project pass the build process and make it able to run.

Cheers
Johannes